### PR TITLE
Fix SIGTERM issues

### DIFF
--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghifari160/ubuntu:16.04
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL MAINTAINER "Ghifari160 <ghifari160@ghifari160.com>"
 
 # Disable interactive elements
 ENV DEBIAN_FRONTEND noninteractive

--- a/16.04/init.sh
+++ b/16.04/init.sh
@@ -32,7 +32,7 @@ fi
 echo "=============================="
 echo "=      Staring Apache2       ="
 echo "=============================="
-/usr/sbin/apachectl -D FOREGROUND
+exec /usr/sbin/apachectl -D FOREGROUND
 echo "=============================="
 echo "=        Ready to Use!       ="
 echo "=============================="

--- a/17.10/Dockerfile
+++ b/17.10/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghifari160/ubuntu:17.10
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL MAINTAINER "Ghifari160 <ghifari160@ghifari160.com>"
 
 # Disable interactive elements
 ENV DEBIAN_FRONTEND noninteractive

--- a/17.10/init.sh
+++ b/17.10/init.sh
@@ -32,7 +32,7 @@ fi
 echo "=============================="
 echo "=      Staring Apache2       ="
 echo "=============================="
-/usr/sbin/apachectl -D FOREGROUND
+exec /usr/sbin/apachectl -D FOREGROUND
 echo "=============================="
 echo "=        Ready to Use!       ="
 echo "=============================="

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghifari160/ubuntu:18.04
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL MAINTAINER "Ghifari160 <ghifari160@ghifari160.com>"
 
 # Disable interactive elements
 ENV DEBIAN_FRONTEND noninteractive

--- a/18.04/init.sh
+++ b/18.04/init.sh
@@ -32,7 +32,7 @@ fi
 echo "=============================="
 echo "=      Staring Apache2       ="
 echo "=============================="
-/usr/sbin/apachectl -D FOREGROUND
+exec /usr/sbin/apachectl -D FOREGROUND
 echo "=============================="
 echo "=        Ready to Use!       ="
 echo "=============================="


### PR DESCRIPTION
`SIGTERM` was not passed by the init script to the Apache2 binaries. Launching the binaries with `exec` should solve the issue.

__DON'T MERGE UNTIL ALL DEPENDANTS HAVE PORTED BIONIC BEAVER__ 